### PR TITLE
Fix migration index bug and tuning performance

### DIFF
--- a/adapter_sql_aggregation.go
+++ b/adapter_sql_aggregation.go
@@ -14,7 +14,7 @@ func (x *SQLAdapter) Count(query *Query) (uint, error) {
 	}
 
 	key := "COUNT(*)"
-	sql := fmt.Sprintf("SELECT %s FROM (%s) AS `Master`", key, strings.Join(stmt.Table, " UNION "))
+	sql := fmt.Sprintf("SELECT %s FROM (%s) AS `Master`", key, strings.Join(stmt.Table, " UNION ALL "))
 
 	if len(stmt.Where) > 0 {
 		sql += fmt.Sprintf(" WHERE %s", strings.Join(stmt.Where, " AND "))

--- a/adapter_sql_exclusive.go
+++ b/adapter_sql_exclusive.go
@@ -41,14 +41,34 @@ func (x *SQLAdapter) Migrate(query *Query, modelStruct interface{}) error {
 	}
 
 	if len(results) > 0 {
+		sqlIndex := fmt.Sprintf(
+			"SELECT DISTINCT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = %q AND TABLE_NAME = %q;",
+			x.dbName, table)
+
+		indexResults := make([]map[string][]byte, 0)
+		indexResults, err = x.ExecQuery(sqlIndex)
+
+		if err != nil {
+			return err
+		}
+
+		delIndexes := make([]string, 0)
+		syncColumns := make([]*Field, 0)
+		newColumns := make([]*Field, 0)
+		delColumns := make([]string, 0)
+
+		for _, item := range indexResults {
+			idx := strings.TrimSpace(string(item["INDEX_NAME"]))
+			if idx == FieldNamePrimaryKey {
+				continue
+			}
+			delIndexes = append(delIndexes, idx)
+		}
+
 		columnList := make(map[string]int, 0)
 		for i, item := range results {
 			columnList[string(item["COLUMN_NAME"])] = i
 		}
-
-		syncColumns := make([]*Field, 0)
-		newColumns := make([]*Field, 0)
-		delColumns := make([]string, 0)
 
 		positionList := make(map[string]string, 0)
 		for i, fs := range columns {
@@ -73,6 +93,7 @@ func (x *SQLAdapter) Migrate(query *Query, modelStruct interface{}) error {
 
 		sql = fmt.Sprintf("ALTER TABLE `%s`", table)
 		stmt := make([]string, 0)
+
 		if len(newColumns) > 0 {
 			script := x.toSQLSchema(newColumns)
 			for i, item := range newColumns {
@@ -84,6 +105,13 @@ func (x *SQLAdapter) Migrate(query *Query, modelStruct interface{}) error {
 				script[i] = fmt.Sprintf("ADD %s %s", script[i], suffix)
 			}
 			stmt = append(stmt, strings.Join(script, ","))
+		}
+
+		if len(delIndexes) > 0 {
+			for i, item := range delIndexes {
+				delIndexes[i] = fmt.Sprintf("DROP INDEX `%s`", item)
+			}
+			stmt = append(stmt, strings.Join(delIndexes, ","))
 		}
 
 		if len(syncColumns) > 0 {

--- a/adapter_sql_getter.go
+++ b/adapter_sql_getter.go
@@ -29,7 +29,7 @@ func (x *SQLAdapter) Find(query *Query, key *datastore.Key, modelStruct interfac
 	cond := fmt.Sprintf(
 		"`%s` = %q AND `%s` = %q",
 		FieldNameKey, stringPrimaryKey(key), FieldNameParent, key.Parent.String())
-	q := fmt.Sprintf("SELECT * FROM (%s) AS Master WHERE %s", strings.Join(stmt.Table, " UNION"), cond)
+	q := fmt.Sprintf("SELECT * FROM (%s) AS Master WHERE %s", strings.Join(stmt.Table, " UNION ALL"), cond)
 	if len(stmt.Where) > 0 {
 		q += fmt.Sprintf(" AND %s", strings.Join(stmt.Where, " AND "))
 	}
@@ -77,7 +77,7 @@ func (x *SQLAdapter) First(query *Query, modelStruct interface{}) error {
 		return err
 	}
 
-	q := fmt.Sprintf("SELECT * FROM (%s) AS Master", strings.Join(stmt.Table, " UNION "))
+	q := fmt.Sprintf("SELECT * FROM (%s) AS Master", strings.Join(stmt.Table, " UNION ALL "))
 	if len(stmt.Where) > 0 {
 		q += fmt.Sprintf(" WHERE %s", strings.Join(stmt.Where, " AND "))
 	}
@@ -138,7 +138,7 @@ func (x *SQLAdapter) Get(query *Query, modelStruct interface{}) error {
 		return err
 	}
 
-	sql := fmt.Sprintf("SELECT * FROM (%s) AS Master", strings.Join(stmt.Table, " UNION "))
+	sql := fmt.Sprintf("SELECT * FROM (%s) AS Master", strings.Join(stmt.Table, " UNION ALL "))
 	if len(stmt.Where) > 0 {
 		sql += fmt.Sprintf(" WHERE %s", strings.Join(stmt.Where, " AND "))
 	}
@@ -197,7 +197,7 @@ func (x *SQLAdapter) Paginate(query *Query, p *Pagination, modelStruct interface
 	}
 
 	sql := ""
-	selectStmt := fmt.Sprintf("SELECT * FROM (%s) AS Master", strings.Join(stmt.Table, " UNION "))
+	selectStmt := fmt.Sprintf("SELECT * FROM (%s) AS Master", strings.Join(stmt.Table, " UNION ALL "))
 	if len(stmt.Where) > 0 {
 		sql += fmt.Sprintf(" WHERE %s", strings.Join(stmt.Where, " AND "))
 	}
@@ -217,7 +217,7 @@ func (x *SQLAdapter) Paginate(query *Query, p *Pagination, modelStruct interface
 			"%s JOIN (SELECT @ROW_NUM := 0) AS Record",
 			fmt.Sprintf(
 				"SELECT @ROW_NUM := @ROW_NUM + 1 as RowNumber, `%s`, `%s` FROM (%s) AS Master",
-				FieldNameParent, FieldNameKey, strings.Join(stmt.Table, " UNION "))) + sql
+				FieldNameParent, FieldNameKey, strings.Join(stmt.Table, " UNION ALL "))) + sql
 
 		sql2 = fmt.Sprintf(
 			"SELECT %s FROM (%s) AS Temp WHERE CONCAT(Temp.`%s`,%q,Temp.`%s`) = %q;",
@@ -247,8 +247,8 @@ func (x *SQLAdapter) Paginate(query *Query, p *Pagination, modelStruct interface
 	cap := p.Limit
 	if cap <= 0 {
 		cap = DefaultTotalRecord
-	} else if cap > MaxRecord {
-		cap = MaxRecord
+	} else if cap > MaxRecordGet {
+		cap = MaxRecordGet
 	}
 	cap++ // extra one record for pagination
 	sql += fmt.Sprintf(" LIMIT %d", cap)

--- a/constant.go
+++ b/constant.go
@@ -29,7 +29,8 @@ const (
 	KeyLength                  = 767
 	TextLength                 = 255
 	MaxKeyLength               = 1500
-	MaxRecord                  = uint(500)
+	MaxRecordInsert            = uint(500)
+	MaxRecordGet               = uint(1000)
 	MaxSeed                    = int64(9223372036854775807)
 	MinSeed                    = int64(100000000000)
 	MySQLDateTimeFormat        = "2006-01-02 15:04:05"

--- a/query_builder.go
+++ b/query_builder.go
@@ -157,8 +157,8 @@ func (b *Builder) Create(modelStruct interface{}, parentKey interface{}) error {
 	if v.Len() <= 0 {
 		return errors.New("goloquent: no valid record to insert")
 	}
-	if v.Len() > int(MaxRecord) {
-		return fmt.Errorf("goloquent: maximum insert records, %d", MaxRecord)
+	if v.Len() > int(MaxRecordInsert) {
+		return fmt.Errorf("goloquent: maximum insert records, %d", MaxRecordInsert)
 	}
 
 	return b.getAdapter().CreateMulti(b.query, modelStruct, parentKey)
@@ -190,8 +190,8 @@ func (b *Builder) Upsert(modelStruct interface{}, parentKey interface{}) error {
 	if v.Len() <= 0 {
 		return errors.New("goloquent: no valid record to insert")
 	}
-	if v.Len() > int(MaxRecord) {
-		return fmt.Errorf("goloquent: maximum insert records, %d", MaxRecord)
+	if v.Len() > int(MaxRecordInsert) {
+		return fmt.Errorf("goloquent: maximum insert records, %d", MaxRecordInsert)
 	}
 
 	return b.getAdapter().UpsertMulti(b.query, modelStruct, parentKey)


### PR DESCRIPTION
- Fix migration bug on existing indexes
- Increase threshold of maximum insert records
- Replace `UNION` to `UNION ALL` for performance concern