### PR TITLE
feat: context resolution on read query

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,25 @@ func (x *User) Save() (error) {
     }
 ```
 
+### Context Resolution Query 
+
+```go
+    import "github.com/RevenueMonster/goloquent/db"
+    
+    db.NewQuery().
+        WhereLike("Name", "%name%").
+        First(context.Background(), user)
+    // query: SELECT * FROM `user` WHERE `Name` LIKE "%name%"
+
+    ctx := context.Background()
+    ctx = db.Where("MerchantID", "=", 1234).InjectResolution(ctx)
+
+    db.NewQuery().
+        WhereLike("Name", "%name%").
+        First(ctx, user)
+    // query: SELECT * FROM `user` WHERE `MerchantID` = 1234 AND `Name` LIKE "%name%"
+```
+
 - **Data Type Support for Where Filtering**
 
 The supported data type are :

--- a/builder.go
+++ b/builder.go
@@ -388,8 +388,13 @@ func (b *builder) migrateMultiple(ctx context.Context, models []interface{}) err
 	return nil
 }
 
-func (b *builder) getCommand(e *entity) (*stmt, error) {
+func (b *builder) getCommand(ctx context.Context, e *entity) (*stmt, error) {
 	query := b.query
+	if !b.query.noResolution {
+		queryScope := extractResolution(ctx)
+		query = query.append(queryScope)
+	}
+
 	buf := new(bytes.Buffer)
 	buf.WriteString(b.buildSelect(query).string())
 	buf.WriteString(" FROM " + b.db.dialect.GetTable(e.Name()))
@@ -464,7 +469,7 @@ func (b *builder) get(ctx context.Context, model interface{}, mustExist bool) er
 		return err
 	}
 	e.setName(b.query.table)
-	cmd, err := b.getCommand(e)
+	cmd, err := b.getCommand(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -498,7 +503,7 @@ func (b *builder) getMulti(ctx context.Context, model interface{}) error {
 		return err
 	}
 	e.setName(b.query.table)
-	cmd, err := b.getCommand(e)
+	cmd, err := b.getCommand(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -547,7 +552,7 @@ func (b *builder) paginate(ctx context.Context, p *Pagination, model interface{}
 		return err
 	}
 	e.setName(b.query.table)
-	cmds, err := b.getCommand(e)
+	cmds, err := b.getCommand(ctx, e)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Feature

Allow to inject query to context, and apply query by resolve context stored query.

# Changes

[+] Example of Context Resolution Query
[+] `IgnoreResolution` function to not apply resolution query while need to respect context rules of Go
[+] Add `context` for `getCommand` while building query
[+] Added append merging function for `scope` query object
[+] `InjectResolution` function to inject query to context
[+] `extractResolution` private function for extract query from context