### PR TITLE
feat: replica connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,14 +564,16 @@ func (x *User) Save() (error) {
 
 ## Replica Connection
 
+You always need to have a primary connection then only adding replica connection. Primary connection must be read-write allowed, and replica can be secondary ( read-write ), and readonly connection ( read ). Currently will be round-robin strategy by default and specific resolver in Query.
 
+![Database Replica Resolver drawio (1)](https://user-images.githubusercontent.com/15674107/211081395-1e405879-deb7-4f0d-a465-c81238bc2412.png)
 
 ### Adding Readonly Replica Connection
 
 ```go
     import "github.com/RevenueMonster/goloquent/db"
 
-	dbContext := context.Background()
+    dbContext := context.Background()
     conn, err := db.Open(dbContext, "mysql", db.Config{
         Username: "root",
         Password: "",
@@ -591,21 +593,21 @@ func (x *User) Save() (error) {
         panic("Connection error: ", err)
     }
 
-	if err := conn.Replica(dbContext, "mysql", goloquent.ReplicaConfig{
+    if err := conn.Replica(dbContext, "mysql", goloquent.ReplicaConfig{
         Username: "root",
         Password: "",
         Host: "localhost",
         Port: "3306",
         Database: "test",
-		ReadOnly: true,
-		Native: func(db *sql.DB) {
-			db.SetMaxIdleConns(64)
-			db.SetMaxOpenConns(64)
-			db.SetConnMaxLifetime(time.Minute)
-		},
-	}); err != nil {
-		panic(fmt.Sprintf("Connection errors for mysql replica : %s", err))
-	}
+	ReadOnly: true,
+	Native: func(db *sql.DB) {
+            db.SetMaxIdleConns(64)
+            db.SetMaxOpenConns(64)
+            db.SetConnMaxLifetime(time.Minute)
+        },
+     }); err != nil {
+            panic(fmt.Sprintf("Connection errors for mysql replica : %s", err))
+     }
 ```
 
 ### Adding Secondary Replica Connection
@@ -614,7 +616,7 @@ func (x *User) Save() (error) {
 ```go
     import "github.com/RevenueMonster/goloquent/db"
 
-	dbContext := context.Background()
+    dbContext := context.Background()
     conn, err := db.Open(dbContext, "mysql", db.Config{
         Username: "root",
         Password: "",
@@ -634,20 +636,46 @@ func (x *User) Save() (error) {
         panic("Connection error: ", err)
     }
 
-	if err := conn.Replica(dbContext, "mysql", goloquent.ReplicaConfig{
+    if err := conn.Replica(dbContext, "mysql", goloquent.ReplicaConfig{
         Username: "root",
         Password: "",
         Host: "localhost",
         Port: "3306",
         Database: "test",
-		Native: func(db *sql.DB) {
-			db.SetMaxIdleConns(64)
-			db.SetMaxOpenConns(64)
-			db.SetConnMaxLifetime(time.Minute)
-		},
-	}); err != nil {
-		panic(fmt.Sprintf("Connection errors for mysql replica : %s", err))
-	}
+	Native: func(db *sql.DB) {
+            db.SetMaxIdleConns(64)
+            db.SetMaxOpenConns(64)
+            db.SetConnMaxLifetime(time.Minute)
+        },
+     }); err != nil {
+            panic(fmt.Sprintf("Connection errors for mysql replica : %s", err))
+     }
+```
+
+### Specify replica 
+
+```go
+    import "github.com/RevenueMonster/goloquent/db"
+    import "github.com/RevenueMonster/goloquent"
+    
+    user := new(User)
+    if err := db.Where("Email", "=", "admin@hotmail.com").
+    	ReplicaResolver(goloquent.ReplicaResolvePrimaryOnly). // resolve primary only
+        First(user); err != nil {
+        log.Println(err) // error while retrieving record
+    }
+    
+    if err := db.Where("Email", "=", "admin@hotmail.com").
+    	ReplicaResolver(goloquent.ReplicaResolveSecondaryOnly). // resolve secondary only replicas
+        First(user); err != nil {
+        log.Println(err) // error while retrieving record
+    }
+    
+    if err := db.Where("Email", "=", "admin@hotmail.com").
+    	ReplicaResolver(goloquent.ReplicaResolveReadOnly). // resolve read only replicas
+        First(user); err != nil {
+        log.Println(err) // error while retrieving record
+    }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -600,10 +600,12 @@ You always need to have a primary connection then only adding replica connection
         Port: "3306",
         Database: "test",
 	ReadOnly: true,
-	Native: func(db *sql.DB) {
-            db.SetMaxIdleConns(64)
-            db.SetMaxOpenConns(64)
-            db.SetConnMaxLifetime(time.Minute)
+        Logger: func(stmt *goloquent.Stmt) {
+            log.Println(stmt.TimeElapse()) // elapse time in time.Duration
+            log.Println(stmt.String()) // Sql string without any ?
+            log.Println(stmt.Raw()) // Sql prepare statement
+            log.Println(stmt.Arguments()) // Sql prepare statement's arguments
+            log.Println(fmt.Sprintf("[%.3fms] %s", stmt.TimeElapse().Seconds()*1000, stmt.String()))
         },
      }); err != nil {
             panic(fmt.Sprintf("Connection errors for mysql replica : %s", err))
@@ -642,10 +644,12 @@ You always need to have a primary connection then only adding replica connection
         Host: "localhost",
         Port: "3306",
         Database: "test",
-	Native: func(db *sql.DB) {
-            db.SetMaxIdleConns(64)
-            db.SetMaxOpenConns(64)
-            db.SetConnMaxLifetime(time.Minute)
+        Logger: func(stmt *goloquent.Stmt) {
+            log.Println(stmt.TimeElapse()) // elapse time in time.Duration
+            log.Println(stmt.String()) // Sql string without any ?
+            log.Println(stmt.Raw()) // Sql prepare statement
+            log.Println(stmt.Arguments()) // Sql prepare statement's arguments
+            log.Println(fmt.Sprintf("[%.3fms] %s", stmt.TimeElapse().Seconds()*1000, stmt.String()))
         },
      }); err != nil {
             panic(fmt.Sprintf("Connection errors for mysql replica : %s", err))

--- a/db.go
+++ b/db.go
@@ -215,13 +215,17 @@ func NewDB(ctx context.Context, driver string, charset CharSet, conn sqlCommon, 
 		logger:    logHandler,
 	}
 	dialect.SetDB(client)
+
+	replica := new(replica)
+	replica.readonly = make(map[string]*DB)
+	replica.secondary = make(map[string]*DB)
 	return &DB{
 		id:                  fmt.Sprintf("%s:%d", driver, time.Now().UnixNano()),
 		driver:              driver,
 		name:                dialect.CurrentDB(ctx),
 		client:              client,
 		dialect:             dialect,
-		replica:             new(replica),
+		replica:             replica,
 		replicaPingInterval: 30,
 	}
 }

--- a/db.go
+++ b/db.go
@@ -195,13 +195,14 @@ func (c Client) QueryRow(ctx context.Context, query string, args ...interface{})
 
 // DB :
 type DB struct {
-	id      string
-	driver  string
-	name    string
-	client  Client
-	dialect Dialect
-	omits   []string
-	replica *replica
+	id                  string
+	driver              string
+	name                string
+	client              Client
+	dialect             Dialect
+	omits               []string
+	replica             *replica
+	replicaPingInterval int64
 }
 
 // NewDB :
@@ -215,12 +216,13 @@ func NewDB(ctx context.Context, driver string, charset CharSet, conn sqlCommon, 
 	}
 	dialect.SetDB(client)
 	return &DB{
-		id:      fmt.Sprintf("%s:%d", driver, time.Now().UnixNano()),
-		driver:  driver,
-		name:    dialect.CurrentDB(ctx),
-		client:  client,
-		dialect: dialect,
-		replica: new(replica),
+		id:                  fmt.Sprintf("%s:%d", driver, time.Now().UnixNano()),
+		driver:              driver,
+		name:                dialect.CurrentDB(ctx),
+		client:              client,
+		dialect:             dialect,
+		replica:             new(replica),
+		replicaPingInterval: 30,
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -391,6 +391,23 @@ func (db *DB) RunInTransaction(cb TransactionHandler) error {
 
 // Close :
 func (db *DB) Close() error {
+
+	if db.replica != nil {
+		for _, db := range db.replica.secondary {
+			x, isOk := db.client.sqlCommon.(*sql.DB)
+			if isOk {
+				x.Close()
+			}
+		}
+
+		for _, db := range db.replica.readonly {
+			x, isOk := db.client.sqlCommon.(*sql.DB)
+			if isOk {
+				x.Close()
+			}
+		}
+	}
+
 	x, isOk := db.client.sqlCommon.(*sql.DB)
 	if !isOk {
 		return nil

--- a/qson/qson_test.go
+++ b/qson/qson_test.go
@@ -29,7 +29,7 @@ func TestProperty(t *testing.T) {
 		return
 	}
 
-	fields, err := parser.Parse([]byte(`{
+	fields, _ := parser.Parse([]byte(`{
 		"email":"sianloong90@gmail.com",
 		"status":{"$in":["OK","FAILED"]}
 	}`))

--- a/replica.go
+++ b/replica.go
@@ -1,0 +1,161 @@
+package goloquent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+type replica struct {
+	secondary  []*DB
+	readonly   []*DB
+	roundRobin int64
+}
+
+type replicaResolver int
+
+const (
+	DefaultReplicaResolver replicaResolver = iota
+	ReplicaResolvePrimaryOnly
+	ReplicaResolveSecondaryOnly
+	ReplicaResolveReadOnly
+)
+
+var (
+	writeNext uint32
+	readNext  uint32
+)
+
+func (r *replica) resolveDatabase(resolver replicaResolver, op dbOperation) *DB {
+
+	resolverList := make([]*DB, 0)
+
+	switch resolver {
+
+	case ReplicaResolvePrimaryOnly:
+		return nil
+
+	case ReplicaResolveSecondaryOnly:
+		if len(r.secondary) == 0 {
+			return nil
+		}
+
+		if len(r.secondary) == 1 {
+			return r.secondary[0]
+		}
+
+		resolverList = append(resolverList, r.secondary...)
+
+	case ReplicaResolveReadOnly:
+		if len(r.readonly) == 0 {
+			return nil
+		}
+
+		if len(r.readonly) == 1 {
+			return r.readonly[0]
+		}
+		resolverList = append(resolverList, r.readonly...)
+
+	case DefaultReplicaResolver:
+		if op == operationRead {
+			resolverList = append(resolverList, r.readonly...)
+			if len(resolverList) == 0 {
+				resolverList = append(resolverList, nil)
+			}
+		}
+
+		if op == operationWrite {
+			resolverList = append(resolverList, nil)
+			resolverList = append(resolverList, r.secondary...)
+		}
+
+	}
+
+	next := uint32(0)
+	if op == operationRead {
+		next = atomic.AddUint32(&readNext, 1)
+	} else {
+		next = atomic.AddUint32(&writeNext, 1)
+	}
+
+	return resolverList[int(next)%len(resolverList)]
+}
+
+type ReplicaConfig struct {
+	Username   string
+	Password   string
+	Host       string
+	Port       string
+	Database   string
+	UnixSocket string
+	TLSConfig  string
+	ReadOnly   bool
+	CharSet    *CharSet
+	Logger     LogHandler
+	Native     NativeHandler
+}
+
+func (db *DB) Replica(ctx context.Context, driver string, conf ReplicaConfig) error {
+	// only allow add replicas on primary connection
+	if db.replica == nil {
+		return fmt.Errorf("goloquent: unsupported replica on replica db")
+	}
+
+	driver = strings.TrimSpace(strings.ToLower(driver))
+	dialect, ok := GetDialect(driver)
+	if !ok {
+		panic(fmt.Errorf("goloquent: unsupported database driver %q", driver))
+	}
+
+	config := Config{
+		Username:   conf.Username,
+		Password:   conf.Password,
+		Host:       conf.Host,
+		Port:       conf.Port,
+		TLSConfig:  conf.TLSConfig,
+		Database:   conf.Database,
+		UnixSocket: conf.UnixSocket,
+		CharSet:    conf.CharSet,
+		Logger:     conf.Logger,
+	}
+	config.Normalize()
+
+	conn, err := dialect.Open(config)
+	if err != nil {
+		return err
+	}
+
+	if conf.Native != nil {
+		conf.Native(conn)
+	}
+
+	if err := conn.Ping(); err != nil {
+		return fmt.Errorf("goloquent: %s server has not response", driver)
+	}
+
+	client := Client{
+		driver:    driver,
+		sqlCommon: conn,
+		dialect:   dialect,
+		CharSet:   *config.CharSet,
+		logger:    config.Logger,
+	}
+	dialect.SetDB(client)
+
+	replicaDB := &DB{
+		id:      fmt.Sprintf("%s:%d", driver, time.Now().UnixNano()),
+		driver:  driver,
+		name:    dialect.CurrentDB(ctx),
+		client:  client,
+		dialect: dialect,
+	}
+
+	if conf.ReadOnly {
+		db.replica.readonly = append(db.replica.readonly, replicaDB)
+	} else {
+		db.replica.secondary = append(db.replica.secondary, replicaDB)
+	}
+	return nil
+}

--- a/replica.go
+++ b/replica.go
@@ -113,7 +113,7 @@ type ReplicaConfig struct {
 func (db *DB) ReplicaPingInterval(seconds int64) error {
 	// only allow add replicas on primary connection
 	if db.replica == nil {
-		return fmt.Errorf("goloquent: unsupported replica action on replica db")
+		return fmt.Errorf("goloquent: unsupported replica action on non-primary db")
 	}
 
 	db.replicaPingInterval = seconds
@@ -123,7 +123,7 @@ func (db *DB) ReplicaPingInterval(seconds int64) error {
 func (db *DB) Replica(ctx context.Context, driver string, conf ReplicaConfig) error {
 	// only allow add replicas on primary connection
 	if db.replica == nil {
-		return fmt.Errorf("goloquent: unsupported replica action on replica db")
+		return fmt.Errorf("goloquent: unsupported replica action on non-primary db")
 	}
 
 	driver = strings.TrimSpace(strings.ToLower(driver))

--- a/replica.go
+++ b/replica.go
@@ -60,6 +60,7 @@ func (r *replica) resolveDatabase(resolver replicaResolver, op dbOperation) *DB 
 
 	case DefaultReplicaResolver:
 		if op == operationRead {
+			resolverList = append(resolverList, r.secondary...)
 			resolverList = append(resolverList, r.readonly...)
 			if len(resolverList) == 0 {
 				resolverList = append(resolverList, nil)

--- a/schema.go
+++ b/schema.go
@@ -18,6 +18,16 @@ type CharSet struct {
 	Collation string
 }
 
+var (
+	ReadOnly = Replica{read: true, write: false}
+	RWrite   = Replica{read: true, write: true}
+)
+
+type Replica struct {
+	read  bool
+	write bool
+}
+
 // Schema :
 type Schema struct {
 	Name         string

--- a/schema.go
+++ b/schema.go
@@ -18,16 +18,6 @@ type CharSet struct {
 	Collation string
 }
 
-var (
-	ReadOnly = Replica{read: true, write: false}
-	RWrite   = Replica{read: true, write: true}
-)
-
-type Replica struct {
-	read  bool
-	write bool
-}
-
 // Schema :
 type Schema struct {
 	Name         string

--- a/table.go
+++ b/table.go
@@ -20,17 +20,17 @@ func (t *Table) newQuery() *Query {
 
 // Create :
 func (t *Table) Create(ctx context.Context, model interface{}, parentKey ...*datastore.Key) error {
-	return newBuilder(t.newQuery()).put(ctx, model, parentKey)
+	return newBuilder(t.newQuery(), operationWrite).put(ctx, model, parentKey)
 }
 
 // Upsert :
 func (t *Table) Upsert(ctx context.Context, model interface{}, parentKey ...*datastore.Key) error {
-	return newBuilder(t.newQuery()).upsert(ctx, model, parentKey)
+	return newBuilder(t.newQuery(), operationWrite).upsert(ctx, model, parentKey)
 }
 
 // Migrate :
 func (t *Table) Migrate(ctx context.Context, model interface{}) error {
-	return newBuilder(t.newQuery()).migrate(ctx, model)
+	return newBuilder(t.newQuery(), operationWrite).migrate(ctx, model)
 }
 
 // Exists :
@@ -40,12 +40,12 @@ func (t *Table) Exists(ctx context.Context) bool {
 
 // DropIfExists :
 func (t *Table) DropIfExists(ctx context.Context) error {
-	return newBuilder(t.newQuery()).dropTableIfExists(ctx, t.name)
+	return newBuilder(t.newQuery(), operationDDL).dropTableIfExists(ctx, t.name)
 }
 
 // Truncate :
 func (t *Table) Truncate(ctx context.Context) error {
-	return newBuilder(t.newQuery()).truncate(ctx, t.name)
+	return newBuilder(t.newQuery(), operationWrite).truncate(ctx, t.name)
 }
 
 // // Rename :
@@ -55,12 +55,12 @@ func (t *Table) Truncate(ctx context.Context) error {
 
 // AddIndex :
 func (t *Table) AddIndex(ctx context.Context, fields ...string) error {
-	return newBuilder(t.newQuery()).addIndex(ctx, fields, bTreeIdx)
+	return newBuilder(t.newQuery(), operationDDL).addIndex(ctx, fields, bTreeIdx)
 }
 
 // AddUniqueIndex :
 func (t *Table) AddUniqueIndex(ctx context.Context, fields ...string) error {
-	return newBuilder(t.newQuery()).addIndex(ctx, fields, uniqueIdx)
+	return newBuilder(t.newQuery(), operationDDL).addIndex(ctx, fields, uniqueIdx)
 }
 
 // Select :
@@ -210,7 +210,7 @@ func (t *Table) Update(ctx context.Context, v interface{}) error {
 
 // Save :
 func (t *Table) Save(ctx context.Context, model interface{}) error {
-	return newBuilder(t.newQuery()).save(ctx, model)
+	return newBuilder(t.newQuery(), operationWrite).save(ctx, model)
 }
 
 // Scan :


### PR DESCRIPTION
# Feature

Allow to add multiple replicas such as readonly, secondary replica and resolve using round-robin strategy.

# Changes

[+] Example of Replica Connection
[+] Example of Specify Replica Connection when Querying
[+] Add `Replica` function to DB object
[+] `ReplicaResolver` function to query object for specifying resolver strategy
[+] Add `dbOperation` to `newBuilder(query, operation)` in order to know which operation is going on 